### PR TITLE
Private Clocks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -12,7 +12,8 @@
             "Title": "Create Clock",
             "Name": "Name",
             "Value": "Value",
-            "Size": "Size"
+            "Size": "Size",
+            "Private": "Private"
         },
         "DeleteDialog": {
             "Title": "Delete Clock",

--- a/module/database.js
+++ b/module/database.js
@@ -9,7 +9,7 @@ export class ClockDatabase extends Collection {
         if (!this.#verifyClockData(data)) return;
 
         const clocks = this.#getClockData();
-        const defaultClock = { value: 0, max: 4, name: "New Clock", id: randomID() };
+        const defaultClock = { value: 0, max: 4, name: "New Clock", id: randomID(), private: false };
         const newData = mergeObject(defaultClock, data);
         clocks[newData.id] = newData;
         game.settings.set("global-progress-clocks", "activeClocks", clocks);

--- a/styles/style.css
+++ b/styles/style.css
@@ -187,3 +187,7 @@
 .add-clock-form .dropdown-wrapper .dropdown li:last-child {
     border: 0;
 }
+
+.clock-entry.hidden{
+    display: none;
+}

--- a/templates/clock-add-dialog.hbs
+++ b/templates/clock-add-dialog.hbs
@@ -26,6 +26,10 @@
                 </ul>
             </div>
         </div>
+        <div class="form-group">
+            <label>{{localize "GlobalProgressClocks.CreateDialog.Private"}}</label>
+            <input type="checkbox" name="private" {{checked clock.private}}/>
+        </div>
     </form>
 </div>
 <div class="dialog-buttons">

--- a/templates/clock-panel.hbs
+++ b/templates/clock-panel.hbs
@@ -1,22 +1,43 @@
 <section class="clock-panel {{#if @root.options.editable}}editable{{/if}} {{verticalEdge}}">
     <div class="clock-list">
-        {{#each clocks as |clock|}}
-            <div class="clock-entry" data-id="{{clock.id}}">
-                <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
-                    {{#each clock.spokes}}
-                        <div class="spoke" style="--index: {{ this }}"></div>
-                    {{/each}}
-                </div>
-                <div class="name-section">
-                    {{#if @root.options.editable}}
-                        <div class="controls">
-                            <a data-action="delete-clock"><i class="fas fa-trash"></i></a>
-                            <a data-action="edit-clock"><i class="fas fa-edit"></i></a>
+         {{#each clocks as |clock|}}
+            {{#if clock.private}}
+                {{#if @root.options.editable}} <!-- Must be admin to see private clocks -->
+                    <div class="clock-entry"  data-id="{{clock.id}}">
+                        <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
+                            {{#each clock.spokes}}
+                                <div class="spoke" style="--index: {{ this }}"></div>
+                            {{/each}}
                         </div>
-                    {{/if}}
-                    <div class="name">{{clock.name}}</div>
+                        <div class="name-section">
+                            {{#if @root.options.editable}}
+                                <div class="controls">
+                                    <a data-action="delete-clock"><i class="fas fa-trash"></i></a>
+                                    <a data-action="edit-clock"><i class="fas fa-edit"></i></a>
+                                </div>
+                            {{/if}}
+                            <div class="name"><i class="fas fa-eye-slash"></i> {{clock.name}}</div>
+                        </div>
+                    </div>
+                {{/if}}
+            {{else}}
+            <div class="clock-entry"  data-id="{{clock.id}}">
+                    <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
+                        {{#each clock.spokes}}
+                            <div class="spoke" style="--index: {{ this }}"></div>
+                        {{/each}}
+                    </div>
+                    <div class="name-section">
+                        {{#if @root.options.editable}}
+                            <div class="controls">
+                                <a data-action="delete-clock"><i class="fas fa-trash"></i></a>
+                                <a data-action="edit-clock"><i class="fas fa-edit"></i></a>
+                            </div>
+                        {{/if}}
+                        <div class="name">{{clock.name}}</div>
+                    </div>
                 </div>
-            </div>
+            {{/if}}
         {{/each}}
     </div>
     {{#if @root.options.editable}}

--- a/templates/clock-panel.hbs
+++ b/templates/clock-panel.hbs
@@ -1,7 +1,7 @@
 <section class="clock-panel {{#if @root.options.editable}}editable{{/if}} {{verticalEdge}}">
     <div class="clock-list">
         {{#each clocks as |clock|}}
-            <div class="clock-entry {{#if clock.private}}{{#unless @root.options.editable}}hidden{{/unless}}{{/if}}" data-id="{{clock.id}}">
+            <div class="clock-entry {{#if (and clock.private (not @root.options.editable)}}hidden{{/if}}" data-id="{{clock.id}}">
                 <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
                     {{#each clock.spokes}}
                         <div class="spoke" style="--index: {{ this }}"></div>

--- a/templates/clock-panel.hbs
+++ b/templates/clock-panel.hbs
@@ -1,6 +1,6 @@
 <section class="clock-panel {{#if @root.options.editable}}editable{{/if}} {{verticalEdge}}">
     <div class="clock-list">
-         {{#each clocks as |clock|}}
+        {{#each clocks as |clock|}}
             <div class="clock-entry {{#if clock.private}}{{#unless @root.options.editable}}hidden{{/unless}}{{/if}}" data-id="{{clock.id}}">
                 <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
                     {{#each clock.spokes}}

--- a/templates/clock-panel.hbs
+++ b/templates/clock-panel.hbs
@@ -1,43 +1,22 @@
 <section class="clock-panel {{#if @root.options.editable}}editable{{/if}} {{verticalEdge}}">
     <div class="clock-list">
          {{#each clocks as |clock|}}
-            {{#if clock.private}}
-                {{#if @root.options.editable}} <!-- Must be admin to see private clocks -->
-                    <div class="clock-entry"  data-id="{{clock.id}}">
-                        <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
-                            {{#each clock.spokes}}
-                                <div class="spoke" style="--index: {{ this }}"></div>
-                            {{/each}}
-                        </div>
-                        <div class="name-section">
-                            {{#if @root.options.editable}}
-                                <div class="controls">
-                                    <a data-action="delete-clock"><i class="fas fa-trash"></i></a>
-                                    <a data-action="edit-clock"><i class="fas fa-edit"></i></a>
-                                </div>
-                            {{/if}}
-                            <div class="name"><i class="fas fa-eye-slash"></i> {{clock.name}}</div>
-                        </div>
-                    </div>
-                {{/if}}
-            {{else}}
-            <div class="clock-entry"  data-id="{{clock.id}}">
-                    <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
-                        {{#each clock.spokes}}
-                            <div class="spoke" style="--index: {{ this }}"></div>
-                        {{/each}}
-                    </div>
-                    <div class="name-section">
-                        {{#if @root.options.editable}}
-                            <div class="controls">
-                                <a data-action="delete-clock"><i class="fas fa-trash"></i></a>
-                                <a data-action="edit-clock"><i class="fas fa-edit"></i></a>
-                            </div>
-                        {{/if}}
-                        <div class="name">{{clock.name}}</div>
-                    </div>
+            <div class="clock-entry {{#if clock.private}}{{#unless @root.options.editable}}hidden{{/unless}}{{/if}}" data-id="{{clock.id}}">
+                <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
+                    {{#each clock.spokes}}
+                        <div class="spoke" style="--index: {{ this }}"></div>
+                    {{/each}}
                 </div>
-            {{/if}}
+                <div class="name-section">
+                    {{#if @root.options.editable}}
+                        <div class="controls">
+                            <a data-action="delete-clock"><i class="fas fa-trash"></i></a>
+                            <a data-action="edit-clock"><i class="fas fa-edit"></i></a>
+                        </div>
+                    {{/if}}
+                    <div class="name">{{#if clock.private}}<i class="fas fa-eye-slash"></i>{{/if}} {{clock.name}}</div>
+                </div>
+            </div>
         {{/each}}
     </div>
     {{#if @root.options.editable}}

--- a/templates/clock-panel.hbs
+++ b/templates/clock-panel.hbs
@@ -1,7 +1,7 @@
 <section class="clock-panel {{#if @root.options.editable}}editable{{/if}} {{verticalEdge}}">
     <div class="clock-list">
         {{#each clocks as |clock|}}
-            <div class="clock-entry {{#if (and clock.private (not @root.options.editable)}}hidden{{/if}}" data-id="{{clock.id}}">
+            <div class="clock-entry {{#if (and clock.private (not @root.options.editable))}}hidden{{/if}}" data-id="{{clock.id}}">
                 <div class="clock" style="--areas: {{clock.max}}; --filled: {{clock.value}}; --clock-color: {{clock.color}}">
                     {{#each clock.spokes}}
                         <div class="spoke" style="--index: {{ this }}"></div>


### PR DESCRIPTION
Added ability for GMs to create private clocks that can not be viewed by players.

- There is a checkbox on the edit dialog to make a clock private.
- An eye slash icon will appear next to the name of a clock to inform the GM that it is private.